### PR TITLE
Feature/pk tweaks

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+<dev@helixhorned.de> <philipp.kutin@gmail.com>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ and it takes a little time.
 
 ### Keybindings
 
+* ?: describe character
 * C-f: forward
 * C-b: backward
 * C-n: next line

--- a/charmap.el
+++ b/charmap.el
@@ -36,11 +36,6 @@
   :prefix "charmap-"
   :group 'applications)
 
-(defcustom charmap-enable-simple nil
-  "Display a result in minibuffer"
-  :type 'symbol
-  :group 'charmap)
-
 (defcustom charmap-text-scale-adjust 4
   "Text scale."
   :type 'integer

--- a/charmap.el
+++ b/charmap.el
@@ -41,6 +41,11 @@
   :type 'integer
   :group 'charmap)
 
+(defcustom charmap-newline-period 48
+  "If greater than zero, the number of Unicode characters after which a newline should be printed."
+  :type 'integer
+  :group 'charmap)
+
 (defface charmap-face '((t (:family "dejavu sans" :weight normal :slant normal :underline nil)))
   "Font lock face used to *charmap* buffer."
   :group 'charmap)
@@ -436,6 +441,12 @@ Non-nil POSITION means use the character at POSITION."
 (defun charmap-print-chars (start-incl end-incl)
   "Print characters from start to end."
   (dolist (ch (number-sequence start-incl end-incl))
+    (if (let ((ii (- ch start-incl)))
+          (and (> ii 0)  ;; we do not want an initial newline
+               (integerp charmap-newline-period)
+               (> charmap-newline-period 0)
+               (= (mod ii charmap-newline-period) 0)))
+        (insert-char 10))  ;; Newline. FIXME: it is selectable.
     (insert-char ch 1)))
 
 (defun charmap-print (unicode-block)

--- a/charmap.el
+++ b/charmap.el
@@ -394,6 +394,7 @@
 
 (defun charmap-describe-char ()
   "Display description of a character at current point."
+  (interactive)
   (describe-char (point))
   (if (equal (current-buffer) (get-buffer charmap-describe-char-bufname))
       (other-window -1)))
@@ -422,6 +423,7 @@ Non-nil POSITION means use the character at POSITION."
 
 (defvar charmap-keymap
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "?") 'charmap-describe-char)
     (define-key map (kbd "C-f") 'charmap-forward)
     (define-key map (kbd "C-b") 'charmap-backward)
     (define-key map (kbd "C-n") 'charmap-next-line)

--- a/charmap.el
+++ b/charmap.el
@@ -52,6 +52,9 @@
 
 (defvar charmap-bufname "*charmap*")
 
+(defvar charmap-block-history-list nil
+  "List of all Unicode blocks that the user has visited.")
+
 (defface charmap-onechar-face '((t (:family "dejavu sans" :weight normal :slant normal :underline nil)))
   "Popup tooltip face."
   :group 'charmap)
@@ -483,9 +486,11 @@ Non-nil POSITION means use the character at POSITION."
   "Display a specified unicode block."
   (interactive)
   (let* ((blocks (mapcar #'(lambda(x) (subst-char-in-string ?_ ?\s (symbol-name x))) (charmap-get-blocks)))
-         (unicode-block (intern-soft (subst-char-in-string ?\s ?_
-                                                           (let ((completion-ignore-case t))
-                                                             (completing-read "Select a unicode block: " blocks))))))
+         (unicode-block
+          (intern-soft
+           (subst-char-in-string
+            ?\s ?_ (let ((completion-ignore-case t))
+                     (completing-read "Select a unicode block: " blocks nil nil nil 'charmap-block-history-list))))))
     (if (plist-get charmap-char-map unicode-block)
         (with-charmap-buffer
          (charmap-print unicode-block))

--- a/charmap.el
+++ b/charmap.el
@@ -477,7 +477,9 @@ Non-nil POSITION means use the character at POSITION."
   "Display a specified unicode block."
   (interactive)
   (let* ((blocks (mapcar #'(lambda(x) (subst-char-in-string ?_ ?\s (symbol-name x))) (charmap-get-blocks)))
-         (unicode-block (intern-soft (subst-char-in-string ?\s ?_ (completing-read "Select a unicode block: " blocks)))))
+         (unicode-block (intern-soft (subst-char-in-string ?\s ?_
+                                                           (let ((completion-ignore-case t))
+                                                             (completing-read "Select a unicode block: " blocks))))))
     (if (plist-get charmap-char-map unicode-block)
         (with-charmap-buffer
          (charmap-print unicode-block))


### PR DESCRIPTION
Various usability tweaks. (In my opinion enhancements, of course, but your mileage may vary.)

I'm not yet very happy that the now-local history list is not persisted, but then maybe it is of not much practical relevance as the few Unicode blocks you're working with regularly are presumably easily remembered. Time will tell.

I'm sorry if `charmap-enable-simple` is present for a future feature (just looked at the issues list).
As a matter of rule I remove everything unused from code I work with, but of course that commit can be easily dropped if the variable is intended to stay.

EDIT: ~~builds~~ based on `feature/update-to-blocks-13.0.0` (PR #12); I created two pull request because I expect this one to be potentially controversial.